### PR TITLE
python-buildfarm deb package is broken on python 2

### DIFF
--- a/buildfarm/release_jobs.py
+++ b/buildfarm/release_jobs.py
@@ -100,7 +100,9 @@ def compute_missing(distros, arches, fqdn, rosdistro, sourcedeb_only=False):
 
 
 def check_for_circular_dependencies(dependencies):
-    deps = {k: set(v) for k, v in dependencies.iteritems()}
+    deps = dict()
+    for k, v in dependencies.iteritems():
+      deps[k] = set(v)
     try:
         _remove_leafs_recursively(deps)
     except RuntimeError:


### PR DESCRIPTION
I'm using python-buildfarm in my simple build scripts for resolving dependencies between packages - the script itself attempts to make a debian package using make deb_dist, and it fails to install because it only requires Python 2.6 and it uses this dict comprehension.

This fixes it so that it installs fine and should be equivalent.
