### PR TITLE
remove apt calls from job

### DIFF
--- a/resources/static_jobs/_rosdistro-build-cache.xml
+++ b/resources/static_jobs/_rosdistro-build-cache.xml
@@ -30,7 +30,7 @@ Generated from buildfarm/resources/static_jobs. Do not edit on Jenkins but in th
   <concurrentBuild>false</concurrentBuild>
   <builders>
     <hudson.tasks.Shell>
-      <command>#!/bin/bash
+      <command>#!/usr/bin/env bash
 INDEX_URL=`python -c "import rosdistro; print(rosdistro.get_index_url())"`
 rosdistro_build_cache $INDEX_URL --debug
 


### PR DESCRIPTION
rosdistro is kept up to date via puppet on all the executors. This wastes time and can collide with the puppet instance. more of #126
