### PR TITLE
Adding ssh-keys to the release configurations.

### DIFF
--- a/resources/static_jobs/_groovy-reconfigure-release-jobs.xml
+++ b/resources/static_jobs/_groovy-reconfigure-release-jobs.xml
@@ -53,13 +53,8 @@ Generated from buildfarm/resources/static_jobs. Do not edit on Jenkins but in th
     <hudson.tasks.Shell>
       <command>#!/bin/bash
 
-#whoami
-#sudo apt-get update
-#sudo apt-get install -y python-vcstools
-dpkg -l | grep vcstools
-
 source ./setup.sh
-./scripts/create_release_jobs.py groovy --repo-work $WORKSPACE/groovyrepo/ --commit --delete</command>
+./scripts/create_release_jobs.py groovy --repo-work $WORKSPACE/groovyrepo/ --ssh-key-id 6967d370-5376-437b-b26a-55da4c72bd84 --commit --delete</command>
     </hudson.tasks.Shell>
   </builders>
   <publishers>

--- a/resources/static_jobs/_hydro-reconfigure-release-jobs.xml
+++ b/resources/static_jobs/_hydro-reconfigure-release-jobs.xml
@@ -53,13 +53,8 @@ Generated from buildfarm/resources/static_jobs. Do not edit on Jenkins but in th
     <hudson.tasks.Shell>
       <command>#!/bin/bash
 
-#whoami
-#sudo apt-get update
-#sudo apt-get install -y python-vcstools
-dpkg -l | grep vcstools
-
 source ./setup.sh
-./scripts/create_release_jobs.py hydro --repo-work $WORKSPACE/hydrorepo/ --commit --delete</command>
+./scripts/create_release_jobs.py hydro --repo-work $WORKSPACE/hydrorepo/ --ssh-key-id 6967d370-5376-437b-b26a-55da4c72bd84 --commit --delete</command>
     </hudson.tasks.Shell>
   </builders>
   <publishers>

--- a/resources/static_jobs/_indigo-reconfigure-release-jobs.xml
+++ b/resources/static_jobs/_indigo-reconfigure-release-jobs.xml
@@ -53,13 +53,8 @@ Generated from buildfarm/resources/static_jobs. Do not edit on Jenkins but in th
     <hudson.tasks.Shell>
       <command>#!/bin/bash
 
-#whoami
-#sudo apt-get update
-#sudo apt-get install -y python-vcstools
-dpkg -l | grep vcstools
-
 source ./setup.sh
-./scripts/create_release_jobs.py indigo --repo-work $WORKSPACE/indigorepo/ --commit --delete</command>
+./scripts/create_release_jobs.py indigo --repo-work $WORKSPACE/indigorepo/ --ssh-key-id 6967d370-5376-437b-b26a-55da4c72bd84 --commit --delete</command>
     </hudson.tasks.Shell>
   </builders>
   <publishers>


### PR DESCRIPTION
Clean up unused lines of command.

The ssh-agent configuration was tested successfully on a full cycle of Indigo
Trust 64 with the keys removed from the slaves. There are other jobs that
will not work without the keys. In particular the ssh-agent does not appear
to penetrate inside the jenkins_tools chroots.
