### PR TITLE
add separate labels since jenkins doesn't track ORd labels correctly

### DIFF
--- a/scripts/manage_storm.py
+++ b/scripts/manage_storm.py
@@ -237,7 +237,7 @@ if number_of_new_machines > 0:
                                          numExecutors=1,
                                          nodeDescription="Standard ROS Build Slave",
                                          remoteFS='/home/rosbuild/hudson',
-                                         labels='devel prerelease released debbuild doc',
+                                         labels='devel prerelease released debbuild groovy_debbuild hydro_debbuild indigo_debbuild doc',
                                          exclusive=True,
                                          launcher={"stapler-class": "hudson.plugins.sshslaves.SSHLauncher", 
                                                    "host": ip,


### PR DESCRIPTION
Once enough of the new machines have this fix, then the job's labels can be updated.
