### PR TITLE
Mark packages with missing package.xml unstable

### DIFF
--- a/buildfarm/release_jobs.py
+++ b/buildfarm/release_jobs.py
@@ -357,7 +357,7 @@ def dry_binarydeb_jobs(stackname, dry_maintainers, rosdistro, distros, arches, f
     return jobs
 
 
-def binarydeb_jobs(package, maintainer_emails, distros, arches, apt_target_repository, fqdn, jobgraph, rosdistro, timeout=None, ssh_key_id=None):
+def binarydeb_jobs(package, maintainer_emails, distros, arches, apt_target_repository, fqdn, jobgraph, rosdistro, short_package_name, timeout=None, ssh_key_id=None):
     jenkins_config = jenkins_support.load_server_config_file(jenkins_support.get_default_catkin_debs_config())
     d = dict(
         ROSDISTRO_INDEX_URL=get_index_url(),
@@ -368,6 +368,7 @@ def binarydeb_jobs(package, maintainer_emails, distros, arches, apt_target_repos
         PACKAGE=package,
         NOTIFICATION_EMAIL=' '.join(maintainer_emails),
         USERNAME=jenkins_config.username,
+        SHORT_PACKAGE_NAME=short_package_name,
         TIMEOUT=timeout,
         SSH_KEY_ID=ssh_key_id
     )
@@ -437,7 +438,7 @@ def dry_doit(package, dry_maintainers, distros, arches, fqdn, rosdistro, jobgrap
 
 def doit(release_uri, package_name, package, distros, arches, apt_target_repository, fqdn, job_graph, rosdistro, short_package_name, commit, jenkins_instance, jenkins_jobs, sourcedeb_timeout=None, binarydeb_timeout=None, ssh_key_id=None):
     maintainer_emails = [m.email for m in package.maintainers]
-    binary_jobs = binarydeb_jobs(package_name, maintainer_emails, distros, arches, apt_target_repository, fqdn, job_graph, rosdistro, timeout=binarydeb_timeout, ssh_key_id=ssh_key_id)
+    binary_jobs = binarydeb_jobs(package_name, maintainer_emails, distros, arches, apt_target_repository, fqdn, job_graph, rosdistro, short_package_name, timeout=binarydeb_timeout, ssh_key_id=ssh_key_id)
     child_projects = zip(*binary_jobs)[0]  # unzip the binary_jobs tuple
     source_job = sourcedeb_job(package_name, maintainer_emails, distros, fqdn, release_uri, child_projects, rosdistro, short_package_name, timeout=sourcedeb_timeout, ssh_key_id=ssh_key_id)
     jobs = [source_job] + binary_jobs

--- a/buildfarm/resources/templates/release_job/binary_build.sh.em
+++ b/buildfarm/resources/templates/release_job/binary_build.sh.em
@@ -7,6 +7,8 @@ export ROSDISTRO_INDEX_URL=@(ROSDISTRO_INDEX_URL)
 APT_TARGET_REPOSITORY=@(APT_TARGET_REPOSITORY)
 ROS_REPO_FQDN=@(FQDN)
 PACKAGE=@(PACKAGE)
+ROSDISTRO=@(ROSDISTRO)
+SHORT_NAME=@(SHORT_PACKAGE_NAME)
 distro=@(DISTRO)
 arch=@(ARCH)
 base=/var/cache/pbuilder-$distro-$arch
@@ -122,7 +124,13 @@ sudo pbuilder  --build \
     --hookdir hooks \
     *.dsc
 
-
+# check for a package.xml
+PACKAGE_XML_MISSING=0
+dpkg -c $output_dir/*$distro* | grep -q ./opt/ros/$ROSDISTRO/share/$SHORT_NAME/package.xml$ || PACKAGE_XML_MISSING=$?
+if [ $PACKAGE_XML_MISSING -ne 0 ]
+then
+    echo "WARNING: The package did not properly install a package.xml"
+fi
 
 # Upload invalidate and add to the repo
 UPLOAD_DIR=/tmp/upload/${PACKAGE}_${distro}_$arch

--- a/buildfarm/resources/templates/release_job/config.binary.xml.em
+++ b/buildfarm/resources/templates/release_job/config.binary.xml.em
@@ -248,6 +248,8 @@ class MatchExtractor {
 // define patterns and extraction parameters
 // catkin_pkg warnings for invalid package.xml files
 warnings_group.match_extractors.add(new MatchExtractor(pattern=Pattern.compile("WARNING\\(s\\) in .*:"), next_lines=1, skip_first_line=true))
+// dpkg warnings for missing package.xml files
+warnings_group.match_extractors.add(new MatchExtractor(pattern=Pattern.compile("WARNING: The package did not properly install a package\\.xml")))
 // custom catkin deprecation messages
 deprecations_group.match_extractors.add(new MatchExtractor(pattern=Pattern.compile(".*\\) is deprecated.*")))
 // c++ compiler warning for usage of a deprecated function


### PR DESCRIPTION
This was discussed in https://github.com/ros/catkin/issues/622

Since I don't have access to the debian buildfarm, someone will need to test this.

Feedback is appreciated.

Thanks,

--scott
