### PR TITLE
increase indigo sync level to 900

### DIFF
--- a/scripts/create_release_jobs.py
+++ b/scripts/create_release_jobs.py
@@ -131,7 +131,7 @@ def doit(rd, distros, arches, apt_target_repository, fqdn, jobs_graph, rosdistro
     elif rosdistro == 'hydro':
         packages_for_sync = 1200
     elif rosdistro == 'indigo':
-        packages_for_sync = 450
+        packages_for_sync = 900
     else:
         packages_for_sync = 10000
 


### PR DESCRIPTION
We're up to 968 packages
