### PR TITLE
Add Indigo to Armhf-indigo debbuild comparison page

### DIFF
--- a/resources/static_jobs/_version_compare.xml
+++ b/resources/static_jobs/_version_compare.xml
@@ -59,6 +59,7 @@ export PYTHONPATH=$WORKSPACE/monitored_vcs
 
 $WORKSPACE/monitored_vcs/scripts/generate_compare_page.py --basedir $WORKSPACE/compare
 $WORKSPACE/monitored_vcs/scripts/generate_compare_page.py indigo jade --basedir $WORKSPACE/compare
+$WORKSPACE/monitored_vcs/scripts/generate_compare_page.py indigo armhf/indigo --basedir $WORKSPACE/compare
 scp -o StrictHostKeyChecking=no -r $WORKSPACE/compare/*.html $WORKSPACE/monitored_vcs/resources/css $WORKSPACE/monitored_vcs/resources/js rosbot@ros.osuosl.org:/var/www/www.ros.org/debbuild/</command>
     </hudson.tasks.Shell>
   </builders>


### PR DESCRIPTION
I'm not even sure if this PR works (can't test since I don't have a server built), but what I want is debbuild comparison page (e.g. [Indigo-Jade](http://www.ros.org/debbuild/compare_indigo_jade.html)) between `armhf` and non-ARM Indigo (since armhf looks like built for Indigo only).
If someone tells me where to modify, I might be able to try updating the PR.